### PR TITLE
Add functions to get all sets or sources, close #6.

### DIFF
--- a/mediacloud/media.py
+++ b/mediacloud/media.py
@@ -33,6 +33,34 @@ def set(media_set_id):
             media_sets[m_id]['media_ids'].append(int(row[2]))
     return media_sets[int(media_set_id)]
 
+def all_sources():
+    '''
+    Call this to get a list of media sources
+    '''
+    global media_sources
+    if media_sources == None: 
+        MEDIA_FILE_PATH = os.path.dirname(__file__)+'/data/media_ids.csv'
+        media_sources = _loadMediaIdsCsv(MEDIA_FILE_PATH)
+    return media_sources.itervalues()
+    
+def all_sets():
+    '''
+    Call this to get a list of all media sets
+    '''
+    global media_sets
+    if media_sets == None: 
+        media_sets = {}
+        MEDIA_FILE_PATH = os.path.dirname(__file__)+'/data/media_sets.csv'
+        media_file = open(MEDIA_FILE_PATH, 'rb')
+        csv_reader = csv.reader(media_file, encoding='utf-8')
+        header = csv_reader.next() # skip header
+        for row in csv_reader:
+            m_id = int(row[0])
+            if m_id not in media_sets:
+                media_sets[m_id] = { 'id': m_id, 'name': row[1], 'media_ids': [] }
+            media_sets[m_id]['media_ids'].append(int(row[2]))
+    return media_sets.itervalues()
+
 def _loadMediaIdsCsv(file_path):
     media_list = {}
     media_file = open(file_path, 'rb')

--- a/mediacloud/test/mediatest.py
+++ b/mediacloud/test/mediatest.py
@@ -14,6 +14,19 @@ class MediaTest(unittest.TestCase):
         media_set = mediacloud.media.set(7125)
         self.assertEquals(media_set['name'],'Political Blogs')
         self.assertEquals(len(media_set['media_ids']), 716)
-
+        
+    def testMediaAllSources(self):
+        media_source = mediacloud.media.all_sources().next()
+        test_name = media_source['name']
+        known_name = mediacloud.media.source(media_source['media_id'])['name']
+        self.assertEquals(test_name, known_name)
+        
+    def testMediaAllSets(self):
+        media_set = mediacloud.media.all_sets().next()
+        known_set = mediacloud.media.set(media_set['id'])
+        test_name = media_set['name']
+        known_name = known_set['name']
+        self.assertEquals(test_name, known_name)
+        
     def suite():
         return unittest.makeSuite(MediaTest, 'test')


### PR DESCRIPTION
mediacloud.media.all_sets() returns a list of media set objects.
mediacloud.media.all_sources() returns a list of media source objects.

Unit tests have been included.
