### PR TITLE
Improve error message and logging for HTTP_STATUS errors

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -140,10 +140,11 @@ class MediaCloud(object):
             params['split_end_date'] = split_end_date
         return self._queryForJson(self.V2_API_URL+'sentences/count', params)
 
-    def wordCount(self, solr_query, solr_filter=''):
+    def wordCount(self, solr_query, solr_filter='', l='en'):
         return self._queryForJson(self.V2_API_URL+'wc/list',
                 {'q': solr_query,
-                 'fq': solr_filter
+                 'fq': solr_filter,
+                 'l': l
                 })
 
     def tag(self, tags_id):


### PR DESCRIPTION
Provide more detailed output in both the log and the exception error message when api.mediacloud.org returns an HTTP status error.

Changes: include the full URL with parameters, include English language name for the error code, include the content of the error page in the log.

These changes make it much easier to understand why a request is failing. And should allow users to give us more informative error messages.
