### PR TITLE
Support for "text=1&sentences=1" in "/stories/single" API call

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -126,12 +126,16 @@ class MediaCloud(object):
                  'rows': rows
                 }) 
 
-    def story(self, stories_id, raw_1st_download=False, corenlp=False):
+    def story(self, stories_id, raw_1st_download=False, corenlp=False, text=False, sentences=False):
         '''
         Details about one story
         '''
         return self._queryForJson(self.V2_API_URL+'stories/single/'+str(stories_id),
-                {'raw_1st_download': 1 if raw_1st_download else 0, 'corenlp': 1 if corenlp else 0} )[0]
+                {'raw_1st_download': 1 if raw_1st_download else 0,
+                 'corenlp': 1 if corenlp else 0,
+                 'text': 1 if text else 0,
+                 'sentences': 1 if sentences else 0
+                })[0]
 
     def storyList(self, solr_query='', solr_filter='', last_processed_stories_id=0, rows=20, 
                   raw_1st_download=False, corenlp=False, show_sentences=True, show_text=True):

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -320,9 +320,10 @@ class MediaCloud(object):
         if r.status_code is not 200:
             self._logger.error('Bad HTTP response to '+r.url +' : '+str(r.status_code)  + ' ' +  str( r.reason) )
             self._logger.error('\t' + r.content )
-            msg = 'Error - got a HTTP status code of %s with the message "%s"' % (
+            msg = 'Error - got a HTTP status code of %s with the message "%s", body: %s' % (
                 str(r.status_code)
                 , str(r.reason)
+                , str(r.text)
             )
             raise mediacloud.error.MCException(msg, r.status_code)
         return r

--- a/mediacloud/test/apitest.py
+++ b/mediacloud/test/apitest.py
@@ -427,7 +427,7 @@ class WriteableApiTest(unittest.TestCase):
         test_tag_id2 = '8878342' # rahulb@media.mit.edu:test_tag2
         tag_set_name = "rahulb@media.mit.edu"
         # grab some sentence_ids to test with
-        orig_story = self._mc.story(test_story_id)
+        orig_story = self._mc.story(test_story_id, sentences=True)
         self.assertTrue( 'story_sentences' in orig_story )
         self.assertTrue( len(orig_story['story_sentences']) > 2 )
         sentence_ids = [ s['story_sentences_id'] for s in orig_story['story_sentences'][0:2] ]
@@ -437,7 +437,7 @@ class WriteableApiTest(unittest.TestCase):
         response = self._mc.tagSentences(desired_tags)
         self.assertEqual(len(response),len(desired_tags))
         # and verify it worked
-        tagged_story = self._mc.story(test_story_id)
+        tagged_story = self._mc.story(test_story_id, sentences=True)
         tagged_sentences = [ s for s in orig_story['story_sentences'] if len(s['tags']) > 0 ]
         for s in tagged_sentences:
             if s['story_sentences_id'] in sentence_ids:
@@ -448,7 +448,7 @@ class WriteableApiTest(unittest.TestCase):
         response = self._mc.tagSentences(desired_tags)
         self.assertEqual(len(response),len(desired_tags))
         # and verify it worked
-        tagged_story = self._mc.story(test_story_id)
+        tagged_story = self._mc.story(test_story_id, sentences=True)
         tagged_sentences = [ s for s in tagged_story['story_sentences'] if len(s['tags']) > 0 ]
         for s in tagged_sentences:
             if s['story_sentences_id'] in sentence_ids:
@@ -460,7 +460,7 @@ class WriteableApiTest(unittest.TestCase):
         response = self._mc.tagSentences(desired_tags, clear_others=True)
         self.assertEqual(len(response),len(desired_tags))
         # and check it
-        tagged_story = self._mc.story(test_story_id)
+        tagged_story = self._mc.story(test_story_id, sentences=True)
         tagged_sentences = [ s for s in tagged_story['story_sentences'] if len(s['tags']) > 0 ]
         for s in tagged_sentences:
             if s['story_sentences_id'] in sentence_ids:

--- a/mediacloud/test/apitest.py
+++ b/mediacloud/test/apitest.py
@@ -428,6 +428,7 @@ class WriteableApiTest(unittest.TestCase):
         tag_set_name = "rahulb@media.mit.edu"
         # grab some sentence_ids to test with
         orig_story = self._mc.story(test_story_id)
+        self.assertTrue( 'story_sentences' in orig_story )
         self.assertTrue( len(orig_story['story_sentences']) > 2 )
         sentence_ids = [ s['story_sentences_id'] for s in orig_story['story_sentences'][0:2] ]
         # add a tag


### PR DESCRIPTION
Hi Rahul,

`/api/v2/stories/single` now requires `text=1` parameter to return story text and `sentences=1` parameter to return a list of story's sentences.

I've updated your API client and its unit tests accordingly. Please let me know what you think.

Linas