### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.2"
     - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
     - "3.4"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-    - pip install requests
+    - pip install .
+    - pip install -r requirements.txt
 # command to run tests, e.g. python setup.py test
 script:
     - python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - "2.7"
+    # Unit tests on Python 3 fail because of ImportErrors:
     # - "3.2"
     # - "3.3"
     # - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ env:
 before_install:
     - cp mc-client.config.template mc-client.config
     - sed -i "s/api_v2_key/$MC_API_KEY/" mc-client.config
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     - pip install .
     - pip install -r requirements.txt
-# command to run tests, e.g. python setup.py test
 script:
     - python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 python:
-  - "2.7"
-  - "2.6"
+    - "2.6"
+    - "2.7"
+    - "3.2"
+    - "3.3"
+    - "3.4"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: "pip install requests"
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ env:
     global:
         - secure: "B+x0vkhdhEmE+U+c6FrHAmAcq20KWz+cVgk58yKSpGIFam2FTatrXVO1VD1rBnOzmSU7GJwmbkUA5wzO+LhZOLd7eiU5S8cqQdIjGjh1JmmM50td/DLNU7kPGsEVurgAWh924/S8rUEVP+wMCgqYmu/P6uQlafArai+isBU5eFA="
 before_install:
+    # Install MongoDB for storage tests
+    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+    - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+    - sudo apt-get update
+    - sudo apt-get install -y mongodb-org
+    # Set up test configuration
     - cp mc-client.config.template mc-client.config
     - sed -i "s/api_v2_key/$MC_API_KEY/" mc-client.config
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
     - "2.7"
-    - "3.2"
-    - "3.3"
-    - "3.4"
+    # - "3.2"
+    # - "3.3"
+    # - "3.4"
 env:
     global:
         - secure: "B+x0vkhdhEmE+U+c6FrHAmAcq20KWz+cVgk58yKSpGIFam2FTatrXVO1VD1rBnOzmSU7GJwmbkUA5wzO+LhZOLd7eiU5S8cqQdIjGjh1JmmM50td/DLNU7kPGsEVurgAWh924/S8rUEVP+wMCgqYmu/P6uQlafArai+isBU5eFA="

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
     - "3.3"
     - "3.4"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: "pip install requests"
+install:
+    - pip install requests
 # command to run tests, e.g. python setup.py test
-script:  python test.py
+script:
+    - python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
     - cp mc-client.config.template mc-client.config
     - sed -i "s/api_v2_key/$MC_API_KEY/" mc-client.config
 install:
-    - pip install .
-    - pip install -r requirements.txt
+    - pip install --allow-external pypubsub .
+    - pip install --allow-external pypubsub -r requirements.txt
 script:
     - python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ python:
     - "3.2"
     - "3.3"
     - "3.4"
+env:
+    global:
+        - secure: "B+x0vkhdhEmE+U+c6FrHAmAcq20KWz+cVgk58yKSpGIFam2FTatrXVO1VD1rBnOzmSU7GJwmbkUA5wzO+LhZOLd7eiU5S8cqQdIjGjh1JmmM50td/DLNU7kPGsEVurgAWh924/S8rUEVP+wMCgqYmu/P6uQlafArai+isBU5eFA="
+before_install:
+    - cp mc-client.config.template mc-client.config
+    - sed -i "s/api_v2_key/$MC_API_KEY/" mc-client.config
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     # - "3.4"
 env:
     global:
-        - secure: "B+x0vkhdhEmE+U+c6FrHAmAcq20KWz+cVgk58yKSpGIFam2FTatrXVO1VD1rBnOzmSU7GJwmbkUA5wzO+LhZOLd7eiU5S8cqQdIjGjh1JmmM50td/DLNU7kPGsEVurgAWh924/S8rUEVP+wMCgqYmu/P6uQlafArai+isBU5eFA="
+        - secure: "1FKYs8WYCo9Wzvnvb5qQ+8sNn/UGbLyaqkYdzVQPYSyFSaAPi88sGEki7au7OsMNkxlvPyjTcjRyoa+GuEOQ5bKPFshGwmBMbanjqV2Cl7anwB9cM51mmHmTffAAazTkxrXxdQviuVu6vcJ77OUrkuCvTstj9kHIbKbTN3573VA="
 before_install:
     # Install MongoDB for storage tests
     - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install requests
 
 If you want to use the storage helpers built in, then run:
 ```
-pip install pypubsub pymongo couchdb-python
+pip install pypubsub pymongo couchdb
 ```
 
 Examples

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 pypubsub
 pymongo
-couchdb-python
+couchdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
-
+pypubsub
+pymongo
+couchdb-python

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import unittest, logging
+import sys
 
 from mediacloud.test.apitest import *
 from mediacloud.test.storagetest import *
@@ -33,6 +34,8 @@ suites = [ unittest.TestLoader().loadTestsFromTestCase(test_class) for test_clas
 
 if __name__ == "__main__":
 	suite = unittest.TestSuite(suites)
-	unittest.TextTestRunner(verbosity=2).run(suite)	
+	test_result = unittest.TextTestRunner(verbosity=2).run(suite)
+	if not test_result.wasSuccessful():
+		sys.exit(1)
 
 # SUITE THESE ALL UP for better outputs


### PR DESCRIPTION
Hi again Rahul,

While testing the `/stories/single` change, I've also added Travis CI support that you might decide to use.

Here's a sample passing build with both the `/stories/single` and this branch merged together: https://travis-ci.org/pypt/MediaCloud-API-Client/builds/44620584

Please note that the Travis CI configuration (`.travis.yml`) uses your Media Cloud API key (for the encrypted value, see `env/global/secure/` entry in `.travis.yml`). If you merge this pull request, and on every API key change, you'll need to encrypt it by running:

    gem install travis
    travis encrypt MC_API_KEY=your_key

...and put the new value to `.travis.yml`.