### PR TITLE
Allow the all_fields parameter to be used on requests to the Media Cloud API

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -18,12 +18,17 @@ class MediaCloud(object):
 
     SENTENCE_PUBLISH_DATE_FORMAT = "%Y-%m-%d %H:%M:%S" # use with datetime.datetime.strptime
 
-    _all_fields = False
-
-    def __init__(self, auth_token=None):
+    def __init__(self, auth_token=None, all_fields=False):
         self._logger = logging.getLogger(__name__)
         self.setAuthToken(auth_token)
+        self.setAllFields(all_fields)
 
+    def setAllFields(self, all_fields):
+        '''
+        Specify the value of the all_fields param to use for all future requests
+        '''
+        self._all_fields = all_fields
+        
     def setAuthToken(self, auth_token):
         '''
         Specify the auth_token to use for all future requests

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -18,6 +18,8 @@ class MediaCloud(object):
 
     SENTENCE_PUBLISH_DATE_FORMAT = "%Y-%m-%d %H:%M:%S" # use with datetime.datetime.strptime
 
+    _all_fields = False
+
     def __init__(self, auth_token=None):
         self._logger = logging.getLogger(__name__)
         self.setAuthToken(auth_token)
@@ -298,6 +300,9 @@ class MediaCloud(object):
         if 'key' not in params:
             params['key'] = self._auth_token
         if http_method is 'GET':
+            if self._all_fields:
+                params['all_fields'] = 1
+
             try:
                 r = requests.get(url, params=params, headers={ 'Accept': 'application/json'} )
             except Exception as e:


### PR DESCRIPTION
Toggle whether the all_fields parameter is used on requests to the Media Cloud API.
all_fields can now be set in the constructor and also toggled with an accessor method.

To minimize code changes, all_fields is toggled at the object level rather than being set at the method call level.


