### PR TITLE
Improve the installation instructions based on feedback from Berkman interns

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ This is the source code of the python client for the [MediaCloud API v2](https:/
 Installation
 ------------
 
-Download the distribution egg, then run
+Clone this git repo
+
+Install the distribution egg from the ```dist``` directory by running:
+
 ```
-easy_install mediacloud-VERSION-py2.X.egg
+sudo easy_install dist/mediacloud-<VERSION>.egg
+```
+where **<VERSION>** is the egg version. E.g.
+
+```
+sudo easy_install dist/mediacloud-2.22.0-py2.7.egg
 ```
 
 *Dependencies*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install the distribution egg from the ```dist``` directory by running:
 ```
 sudo easy_install dist/mediacloud-<VERSION>.egg
 ```
-where `**<VERSION>**` is the egg version. E.g.
+where `<VERSION>` is the egg version. E.g.
 
 ```
 sudo easy_install dist/mediacloud-2.22.0-py2.7.egg

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install the distribution egg from the ```dist``` directory by running:
 ```
 sudo easy_install dist/mediacloud-<VERSION>.egg
 ```
-where **<VERSION>** is the egg version. E.g.
+where `**<VERSION>**` is the egg version. E.g.
 
 ```
 sudo easy_install dist/mediacloud-2.22.0-py2.7.egg


### PR DESCRIPTION
Explicitly suggest cloning the repo since just installing the egg may not be sufficient.

Also mention that the egg is in the dist directory and be explicit about the need to specify versions.