### PR TITLE
Add helper method to generate publish_date queries and update the documentation examples

### DIFF
--- a/mediacloud/__init__.py
+++ b/mediacloud/__init__.py
@@ -2,5 +2,5 @@
 from api import MediaCloud
 from storage import *
 
-__version__ = '2.22.2'
+__version__ = '2.23.0'
 

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -329,6 +329,33 @@ class MediaCloud(object):
             raise mediacloud.error.MCException(msg, r.status_code)
         return r
 
+    def _zi_time(self, d):
+	return datetime.datetime.combine(d, datetime.time.min).isoformat() + "Z"
+
+    def _solr_date_range( self, start_date, end_date, start_date_inclusive=True, end_date_inclusive=False):
+        ret = ''
+
+        if start_date_inclusive:
+            ret += '['
+        else:
+            ret += '{'
+
+        ret += self._zi_time( start_date )
+
+        ret += " TO "
+
+        ret += self._zi_time( end_date )
+
+        if end_date_inclusive:
+            ret += ']'
+        else:
+            ret += '}'
+
+        return ret
+
+    def publish_date_query( self, start_date, end_date, start_date_inclusive=True, end_date_inclusive=False):
+        return 'publish_date:' + self._solr_date_range( start_date, end_date, start_date_inclusive, end_date_inclusive)
+
 # used when calling AdminMediaCloud.tagStories
 StoryTag = namedtuple('StoryTag',['stories_id','tag_set_name','tag_name'])
 

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -2,6 +2,7 @@ import re, logging, json, urllib, datetime, sys
 from collections import namedtuple
 import xml.etree.ElementTree, requests
 import mediacloud, mediacloud.error
+import datetime
 
 class MediaCloud(object):
     '''

--- a/mediacloud/test/apitest.py
+++ b/mediacloud/test/apitest.py
@@ -61,6 +61,32 @@ class AuthTokenTest(ApiBaseTest):
         except:
             self.assertTrue(True)
 
+class PublishDateQueryTest(ApiBaseTest):
+
+    def testPublishDateQuery(self):
+        start_date = datetime.date(2014,06,02 )
+        end_date = datetime.date(2014,06,03 )
+        date_query_default = self._mc.publish_date_query( start_date, end_date )
+        self.assertEqual( date_query_default, "publish_date:[2014-06-02T00:00:00Z TO 2014-06-03T00:00:00Z}" )
+
+        date_query_inclusive_exclusive = self._mc.publish_date_query( start_date, end_date, start_date_inclusive=True, end_date_inclusive=False)
+        self.assertEqual( date_query_inclusive_exclusive, "publish_date:[2014-06-02T00:00:00Z TO 2014-06-03T00:00:00Z}") 
+
+        date_query_inclusive_inclusive = self._mc.publish_date_query( start_date, end_date, start_date_inclusive=True, end_date_inclusive=True)
+        self.assertEqual( date_query_inclusive_inclusive, "publish_date:[2014-06-02T00:00:00Z TO 2014-06-03T00:00:00Z]") 
+
+        date_query_exclusive_inclusive = self._mc.publish_date_query( start_date, end_date, start_date_inclusive=False, end_date_inclusive=True)
+        self.assertEqual( date_query_exclusive_inclusive, "publish_date:{2014-06-02T00:00:00Z TO 2014-06-03T00:00:00Z]") 
+
+        date_query_exclusive_exclusive = self._mc.publish_date_query( start_date, end_date, start_date_inclusive=False, end_date_inclusive=False)
+        self.assertEqual( date_query_exclusive_exclusive, "publish_date:{2014-06-02T00:00:00Z TO 2014-06-03T00:00:00Z}") 
+
+        self.assertTrue( self._mc.sentenceCount( date_query_default )[ 'count' ] > 0 )
+        self.assertTrue( self._mc.sentenceCount( date_query_inclusive_exclusive )[ 'count' ] > 0 )
+        self.assertTrue( self._mc.sentenceCount( date_query_inclusive_inclusive )[ 'count' ] > 0 )
+        self.assertTrue( self._mc.sentenceCount( date_query_exclusive_exclusive )[ 'count' ] > 0 )
+        self.assertTrue( self._mc.sentenceCount( date_query_exclusive_inclusive )[ 'count' ] > 0 )
+
 class ApiMediaTest(ApiBaseTest):
 
     def testMedia(self):

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@ test_classes = [
     ApiControversyTest, ApiControversyDumpTest, ApiControversyDumpTimeSliceTest,
     AuthTokenTest,
     ApiAllFieldsOptionTest,
+    PublishDateQueryTest,
     AdminApiTaggingContentTest, AdminApiTaggingUpdateTest
 ]
 


### PR DESCRIPTION
Add helper method to generate publish_date queries.
Update the documentation examples
The code already supported passing an array to the solr_filter parameters so use that method in the example code.

Add test cases for publishdatequery

