### PR TITLE
warn user if no sources or collections specified

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -8,21 +8,11 @@ import requests
 
 import mediacloud
 import mediacloud.error
-from mediacloud.types import (
-    Collection,
-    CountOverTimePoint,
-    JSONObj,
-    LanguageCount,
-    OffsetPage,
-    PaginationToken,
-    Source,
-    SourceIntervalAttention,
-    SourceCount,
-    SourceWeekAttention,
-    Story,
-    StoryCount,
-    VersionInfo,
-)
+from mediacloud.types import (Collection, CountOverTimePoint, JSONObj,
+                              LanguageCount, OffsetPage, PaginationToken,
+                              Source, SourceCount, SourceIntervalAttention,
+                              SourceWeekAttention, Story, StoryCount,
+                              VersionInfo)
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +158,10 @@ class SearchApi(BaseApi):
 
         params: Dict[Any, Any] = dict(start=start_date.isoformat(), end=end_date.isoformat(), q=query,
                                       platform=(platform or self.PROVIDER))
+
+        if (len(source_ids) + len(collection_ids)) == 0:
+            warnings.warn("No sources or collections specified. This is a *BAD IDEA*. Pick a collection.")
+
         if len(source_ids):
             params['ss'] = ",".join([str(sid) for sid in source_ids]),
         if len(collection_ids):
@@ -197,8 +191,8 @@ class SearchApi(BaseApi):
         return results['source-week-attention']
 
     def stories_by_source_over_interval(self, query: str, start_date: dt.date, end_date: dt.date,
-                                    collection_ids: Optional[List[int]] = [], source_ids: Optional[List[int]] = [],
-                                    platform: Optional[str] = None, interval: Optional[str] = None) -> List[SourceIntervalAttention]:
+                                        collection_ids: Optional[List[int]] = [], source_ids: Optional[List[int]] = [],
+                                        platform: Optional[str] = None, interval: Optional[str] = None) -> List[SourceIntervalAttention]:
         params = self._prep_default_params(query, start_date, end_date, collection_ids, source_ids, platform)
         if interval:
             params['interval'] = interval

--- a/mediacloud/test/api_search_test.py
+++ b/mediacloud/test/api_search_test.py
@@ -14,7 +14,7 @@ TOMORROW_TIME = dt.datetime.today() + dt.timedelta(days=1)
 START_DATE = dt.date(2023, 11, 1)
 END_DATE = dt.date(2023, 12, 1)
 
-#Optionally override the target instance when testing, for staging/dev cases
+# Optionally override the target instance when testing, for staging/dev cases
 mediacloud.api.BaseApi.BASE_API_URL = os.getenv("MC_API_BASE_URL", "https://search.mediacloud.org/api/")
 
 
@@ -353,6 +353,17 @@ class SearchErrorHandlingTest(TestCase):
                                                            collection_ids=[COLLECTION_US_NATIONAL])['relevant']
 
         assert result_via_date == result_via_datetime
+
+    def test_warnings(self):
+        with patch.object(self._search, "_query", return_value={"count": {}}):
+            with pytest.warns(UserWarning, match="start_date was passed as datetime"):
+                self._search.story_count(query="biden", start_date=self.START_DATETIME, end_date=self.END_DATE,
+                                         collection_ids=[COLLECTION_US_NATIONAL])
+            with pytest.warns(UserWarning, match="end_date was passed as datetime"):
+                self._search.story_count(query="biden", start_date=self.START_DATE, end_date=self.END_DATETIME,
+                                         collection_ids=[COLLECTION_US_NATIONAL])
+            with pytest.warns(UserWarning, match="No sources or collections specified"):
+                self._search.story_count(query="biden", start_date=self.START_DATE, end_date=self.END_DATE)
 
     def test_stories_by_source_over_interval_day(self):
         expected = [{


### PR DESCRIPTION
Another tiny change - add a warning if the user queries with no sources or collections. Maybe they'll see it, maybe they won't, but it's a first step in advising better usage when they use the API client. Includes unit test.

Other ideas we've discussed:
* throwing an error in api client to not allow this kind of usage
* adding a check on server to reject no-source/no-collection queries unless user is admin
